### PR TITLE
[FEAT] GraphQL 쿼리 임시 유틸 타입 생성

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,13 +2,9 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="a589dc9e-e082-451a-aac1-e8f1deb0cc21" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.eslintrc.js" beforeDir="false" afterPath="$PROJECT_DIR$/.eslintrc.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.pnp.cjs" beforeDir="false" afterPath="$PROJECT_DIR$/.pnp.cjs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.yarn/install-state.gz" beforeDir="false" afterPath="$PROJECT_DIR$/.yarn/install-state.gz" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/yarn.lock" beforeDir="false" afterPath="$PROJECT_DIR$/yarn.lock" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/graphql/queries/supportProgramBanners.ts" beforeDir="false" afterPath="$PROJECT_DIR$/graphql/queries/supportProgramBanners.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/graphql/types.ts" beforeDir="false" afterPath="$PROJECT_DIR$/graphql/types.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -74,7 +70,8 @@
       <workItem from="1657004279482" duration="6021000" />
       <workItem from="1657070353466" duration="841000" />
       <workItem from="1657073574081" duration="607000" />
-      <workItem from="1657242687360" duration="5132000" />
+      <workItem from="1657242687360" duration="6070000" />
+      <workItem from="1657259847242" duration="1669000" />
     </task>
     <servers />
   </component>

--- a/graphql/queries/supportProgramBanners.ts
+++ b/graphql/queries/supportProgramBanners.ts
@@ -3,7 +3,15 @@ import { gql } from 'graphql-request';
 export const SUPPORT_PROGRAM_BANNERS = gql`
   query SupportProgramBanners {
     supportProgramBanners {
+      amplitudeEvent
+      backgroundColor
+      desktopImageUrl
       link
+      mobileImageUrl
+      subTitle
+      subTitleColor
+      title
+      titleColor
     }
   }
 `;

--- a/graphql/types.ts
+++ b/graphql/types.ts
@@ -450,5 +450,29 @@ export type UpdateCollectionInput = {
 export type SupportProgramBannersQueryVariables = Exact<{ [key: string]: never }>;
 
 export type SupportProgramBannersQuery = {
-  supportProgramBanners: Array<{ link: string | null } | null> | null;
+  supportProgramBanners: Array<{
+    amplitudeEvent: string | null;
+    backgroundColor: string | null;
+    desktopImageUrl: string | null;
+    link: string | null;
+    mobileImageUrl: string | null;
+    subTitle: string | null;
+    subTitleColor: string | null;
+    title: string | null;
+    titleColor: string | null;
+  } | null> | null;
+};
+
+export type TechnologiesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type TechnologiesQuery = {
+  technologies: Array<{
+    createdAt: any | null;
+    depth: number | null;
+    id: number | null;
+    name: string | null;
+    parentId: number | null;
+    priority: number | null;
+    count: number | null;
+  } | null> | null;
 };

--- a/graphql/utils.ts
+++ b/graphql/utils.ts
@@ -1,0 +1,29 @@
+import { Maybe } from './types';
+
+/*
+ * 현재 gql-alpha에서 필드의 Nullable한 성질이 제대로 정해지지 않았습니다.
+ * 이에, 임의로 Nullable한 값을 조정할 수 있는 유틸 타입을 만들었습니다.
+ * 이 유틸 파일이 모든 테스트 커버리지를 거치지는 않았지만, 현재 리스트를 리턴하는 GQL 쿼리로 테스트 한 결과 제대로 반영이 되는 것을 확인했습니다.
+ * 문제가 생기면 언제든지 말씀 주세요. 감사합니다.
+ *
+ * T: GraphQL Query
+ * PreservedKeys: null을 유지해야 하는 키의 union
+ * */
+
+export type RecursivelyExcludeNull<T, PreservedKeys = never> = T extends Maybe<infer U>
+  ? U extends Array<infer Elem>
+    ? Elem extends null
+      ? never
+      : Elem extends Maybe<infer ElemVal>
+      ? RecursivelyExcludeNull<ElemVal, PreservedKeys>[]
+      : RecursivelyExcludeNull<Elem, PreservedKeys>[]
+    : U extends object
+    ? {
+        [Key in keyof U]: Key extends PreservedKeys
+          ? U[Key]
+          : U[Key] extends Maybe<infer Property>
+          ? RecursivelyExcludeNull<Property, PreservedKeys>
+          : RecursivelyExcludeNull<U[Key], PreservedKeys>;
+      }
+    : U
+  : T;


### PR DESCRIPTION
현재 gql-alpha에서 필드의 Nullable한 성질이 제대로 정해지지 않았습니다.
이에, 임의로 Nullable한 값을 조정할 수 있는 유틸 타입을 만들었습니다.
이 유틸 파일이 모든 테스트 커버리지를 거치지는 않았지만, 현재 리스트를 리턴하는 GQL 쿼리로 테스트 한 결과 제대로 반영이 되는 것을 확인했습니다.
문제가 생기면 언제든지 말씀 주세요. 감사합니다.

 * T: GraphQL Query
 * PreservedKeys: null을 유지해야 하는 키의 union

[예시](https://www.typescriptlang.org/play?#code/C4TwDgpgBAsghiARhAPAFQHxQLxTVAHygDsBXAG3IG4AoG0SKAZVLDAHsAnYABU-YDmnOAFsAQnGLEInAM4BFUjJA4oAbxpQos1h259Bw8ZOlyAXFACCnYSBQatW0WHIBLYKQAmEAKIA3CGJgC1lgTldiAUISCmpNR0Q4AGMAayF2UmJPAGF2ci4QsIioojJKWkcob1kU4HYwAEkROAEIAFVOckLwyOiyuMq3YhTu4r7YiscRdkRXcggmlvbO0d7SifitHUQ0d3nVkpjyze1SHb2IXPzOA-HjyuAL2-X7x0fgeauC7SK1o4GoABfO7kLAvOLxYAQUIWByOTgQOCUEAAOViFn6ky0rlkaMoFkQ7DyiOIIKxUHe+x+PUOmJOlMueW+oRpZPp0OAACYLNZbPYTlszrsPozrs9-uStAzxXTKsDwWCJfFATRAbR6OBoAAlCBJUhyVwBcggHwADyS5C8EDx5HQABooHxoTIAp4ANIQECyVTSAKcLC4fAQU1QrLe+BIVARABmMigbQw8QA-PGoMHQ55vbyECgY3GfPMRInKimCxARGmQ4FM-8BVAU76ZHWLGWK+nq+GEMhc8RY5woK2AGpI4uVetQHV6g1Gk3my3eG0oIdIh1O2QuiDuz2yDAAbQAus2J7r9bJDRBjWaLVbF63Vwj15xXR6vXvD5ULG1KxnvTMAFa6sAJwpnCY5QLuL5QBEUApJ67DRvG+4WJB7Zho6D4bluXp1iW8YQZ675gY4n74SA+7fh2sBdlGvZxgYkDcCAo5EeOk6nuel5zjesQoPRMigPezpPpuL47jhxHHlOZ4zle87WjxbSkfugmPs+24YJKQInJ+8QWGg6oMNAaAAIyqGx04XrO14LjxLBsFwvD8EIogSFIMgKEonAgA6ABE0yzPMiytB05A+Ymhl4JyqgmbuPlQqEPmHjQQA)
